### PR TITLE
Add Hermes to Customer Service & Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The revenue optimization and customer lifecycle management stage. This final pha
 - [ChatBot.com](https://www.chatbot.com/) - AI chatbot with drag-and-drop Visual Builder
 - [Decagon](https://decagon.ai/) - AI concierge deploying autonomous support agents across chat, email, voice
 - [Fin.ai](https://fin.ai/) - AI customer service agent (formerly Intercom) resolving ~76% across chat, email, voice
+- [Hermes](https://www.buildwithhermes.com/) - White-label AI voice agent platform deploying 24/7 phone agents that answer calls and book appointments across isolated client workspaces
 - [Lorikeet](https://www.lorikeetcx.ai/) - AI concierge resolving complex, multi-step tickets for regulated industries
 - [Maven AGI](https://www.mavenagi.com/) - Enterprise AI agents automating support across chat, email, and voice
 - [Parloa](https://www.parloa.com/) - Agentic AI automating contact-center conversations across voice and digital


### PR DESCRIPTION
Adds Hermes (buildwithhermes.com) to the Customer Service & Support section, alphabetically between Fin.ai and Lorikeet.

Why it fits: the section already covers voice-capable support agents (Parloa, Sierra, Decagon). Hermes covers the same job for the phone channel specifically, AI receptionists that answer every call and book appointments, and adds the agency/multi-tenant angle the section doesn't have yet: one workspace per client, white-label branding, and built-in campaign + CRM tooling.

Entry matches the existing format and description length. Happy to adjust wording or placement.